### PR TITLE
Retag Ensembl VEP docker

### DIFF
--- a/102.0/Dockerfile
+++ b/102.0/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM ensemblorg/ensembl-vep:${VERSION}
+FROM ensemblorg/ensembl-vep:release_${VERSION}
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini

--- a/102.0/Dockerfile
+++ b/102.0/Dockerfile
@@ -1,0 +1,7 @@
+ARG VERSION
+FROM FROM ensemblorg/ensembl-vep:${VERSION}
+
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/vep"]

--- a/102.0/Dockerfile
+++ b/102.0/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM FROM ensemblorg/ensembl-vep:${VERSION}
+FROM ensemblorg/ensembl-vep:${VERSION}
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini

--- a/102.0/Dockerfile
+++ b/102.0/Dockerfile
@@ -1,7 +1,6 @@
 ARG VERSION
 FROM ensemblorg/ensembl-vep:release_${VERSION}
 
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/vep"]
+ENTRYPOINT ["./vep"]
+CMD ["--help"]
+

--- a/102.0/Makefile
+++ b/102.0/Makefile
@@ -29,7 +29,7 @@ build-docker:
 	@echo
 	@echo -- Building docker --
 	docker build . \
-		--file ../Dockerfile.multi \
+		--file ./Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		-t "${DOCKER_IMAGE}" \
 		-t "${DOCKER_IMAGE_HASH}"


### PR DESCRIPTION
Simply retag the VEP docker from Dockerhub and update the entrypoint (only works for VEP 89+)